### PR TITLE
Validate token per run

### DIFF
--- a/backend/api/rms.php
+++ b/backend/api/rms.php
@@ -12,6 +12,8 @@ if (($_SERVER['REQUEST_METHOD'] ?? '') === 'OPTIONS') {
 
 // Include the database configuration file
 include '../config.php';
+include '../methods/authentication.php';
+
 $conn = new mysqli($servername, $username, $password, $dbname);
 if ($conn->connect_error) {
     http_response_code(500);
@@ -104,16 +106,44 @@ switch ($method) {
 
         // Get Player Token
         $token = trim(substr($headers['Authorization'], 6));
+        $data = json_decode(file_get_contents('php://input'), true);
 
-        // Check if token is listed in the database
-        $playerExists = false;
-        if ($stmt = $conn->prepare("SELECT * FROM `players` WHERE `lastToken` = ?")) {
-            $stmt->bind_param("s", $token);
+        if (!isset($data['accountId']) || !isset($data['goal']) || !isset($data['skips']) || !isset($data['time_survived'])) {
+            http_response_code(403);
+            echo json_encode(["success" => false, "message" => "accountId, goal, skips and time_survived must be indicated in the body"]);
+            $conn->close();
+            die();
+        }
+
+        $accountId = $data['accountId'];
+        $objective = isset($data['objective']) ? $data['objective'] : "author";
+        $goals = $data['goal'];
+        $skips = $data['skips'];
+        $timeSurvived = $data['time_survived'];
+
+        if (!IsTokenValid($token, $openplanetSecret, $conn)) {
+            echo json_encode(["success" => false, "message" => "Invalid / Expired Openplanet token received."]);
+            $conn->close();
+            die();
+        }
+
+        if ($stmt = $conn->prepare("SELECT * FROM `players` WHERE `accountId` = ?")) {
+            $stmt->bind_param("s", $accountId);
             $stmt->execute();
             $result = $stmt->get_result();
-            while($row = $result->fetch_assoc()) {
+
+            if ($result->num_rows === 0) {
+                http_response_code(500);
+                echo json_encode(["success" => false, "message" => "Failed to find player in our database."]);
+                $stmt->close();
+                $conn->close();
+                die();
+            }
+
+            while ($row = $result->fetch_assoc()) {
                 $player = $row;
             }
+            $stmt->close();
         } else {
             http_response_code(500);
             echo json_encode(["success" => false, "message" => "Error preparing statement: " . $conn->error]);
@@ -127,21 +157,6 @@ switch ($method) {
             $conn->close();
             die();
         }
-
-        $data = json_decode(file_get_contents('php://input'), true);
-        $accountId = $player['accountId'];
-        $objective = isset($data['objective']) ? $data['objective'] : "author";
-
-        if (!isset($data['goal']) || !isset($data['skips']) || !isset($data['time_survived'])) {
-            http_response_code(403);
-            echo json_encode(["success" => false, "message" => "goal, skips and time_survived must be indicated in the body"]);
-            $conn->close();
-            die();
-        }
-
-        $goals = $data['goal'];
-        $skips = $data['skips'];
-        $timeSurvived = $data['time_survived'];
 
         $stmt = $conn->prepare("INSERT INTO `rms` (`accountId`, `objective`, `submitTime`, `goals`, `skips`, `timeSurvived`) VALUES (?, ?, now(), ?, ?, ?)");
         $stmt->bind_param("ssiii", $accountId, $objective, $goals, $skips, $timeSurvived);

--- a/backend/methods/authentication.php
+++ b/backend/methods/authentication.php
@@ -1,0 +1,71 @@
+<?php
+
+define("OPENPLANET_AUTH_URL", "https://openplanet.dev/api/auth/validate");
+
+function IsTokenValid(string $token, string $secret, mysqli $db) {
+    if (empty($token)) {
+        return false;
+    } else if (str_starts_with($token, 'Bearer ')) {
+        $token = substr($token, 7);
+    }
+
+    $payload = [
+        'token'  => $token,
+        'secret' => $secret,
+    ];
+
+    $options = [
+        'http' => [
+            'method'  => 'POST',
+            'header'  =>
+                "Content-Type: application/x-www-form-urlencoded\r\n" .
+                "User-Agent: PHP/".phpversion()." RMC_API/1.0 (Greep & FlinkTM)\r\n",
+            'content' => http_build_query($payload),
+            'timeout' => 10,
+            'ignore_errors' => true,
+        ]
+    ];
+
+    $context = stream_context_create($options);
+    $openplanetResponse = @file_get_contents(OPENPLANET_AUTH_URL, false, $context);
+
+    if ($openplanetResponse === false) {
+        echo("Openplanet request failed");
+        return false;
+    }
+
+    $openplanetData = json_decode($openplanetResponse, true) ?: [];
+
+    if (empty($openplanetData)) {
+        echo("Openplanet JSON response is empty!");
+        return false;
+    }
+
+    if (isset($openplanetData["error"])) {
+        echo("Error validating Openplanet token: " . $openplanetData["error"]);
+        return false;
+    }
+
+    if (!isset($openplanetData["account_id"])) {
+        echo("Openplanet Token JSON is missing the account ID");
+        return false;
+    }
+
+    $statement = "INSERT INTO `players` (`accountId`, `displayName`, `lastLogon`, `lastPluginVersion`, `lastToken`)
+            VALUES (?, ?, NOW(), '', ?)
+            ON DUPLICATE KEY UPDATE
+            displayName = VALUES(`displayName`), lastLogon = NOW(), lastPluginVersion = VALUES(`lastPluginVersion`), lastToken = VALUES(`lastToken`)";
+
+    if ($stmt = $db->prepare($statement)) {
+        $stmt->bind_param("sss", $openplanetData['account_id'], $openplanetData['display_name'], $token);
+        $stmt->execute();
+        $stmt->close();
+    } else {
+        echo("Failed to prepare statement when getting token from Openplanet");
+        return false;
+    }
+
+    return true;
+}
+
+?>


### PR DESCRIPTION
Basically remove the old auth endpoint (left so old plugin versions don't fail). Now, a new token will be generated per run, and the RMC/S endpoints will validate it against the OP API

This can only be confirmed as working once it's merged, since the current plugin keeps the same token throughout a session. But I can confirm it works locally at least